### PR TITLE
docs: generate README.md from README.Rmd and add codecov badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,18 @@
----
-output: github_document
----
-
 <!-- README.md is generated from README.Rmd. Please edit that file -->
-
-```{r, include = FALSE}
-knitr::opts_chunk$set(
-  collapse = TRUE,
-  comment = "#>",
-  fig.path = "man/figures/README-",
-  out.width = "100%"
-)
-```
 
 # biodiversityhorizons
 
 <!-- badges: start -->
-[![codecov](https://codecov.io/gh/uw-ssec/biodiversity-horizons/graph/badge.svg?token=ee1oeNuMlb)](https://codecov.io/gh/uw-ssec/biodiversity-horizons)
-<!-- badges: end -->
 
+[![codecov](https://codecov.io/gh/uw-ssec/biodiversity-horizons/graph/badge.svg?token=ee1oeNuMlb)](https://codecov.io/gh/uw-ssec/biodiversity-horizons)
+
+<!-- badges: end -->
 
 ## Installation
 
 You can install the development version of biodiversityhorizons like so:
 
-``` r
+```r
 # Install devtools if not already installed
 install.packages("devtools")
 
@@ -36,9 +24,10 @@ devtools::install_github("uw-ssec/biodiversity-horizons")
 
 This is a basic example which shows you how to solve a common problem:
 
-```{r example}
+```r
 library(biodiversityhorizons)
 ## basic example code
 ```
 
-You'll still need to render `README.Rmd` regularly, to keep `README.md` up-to-date. `devtools::build_readme()` is handy for this.
+You’ll still need to render `README.Rmd` regularly, to keep `README.md`
+up-to-date. `devtools::build_readme()` is handy for this.


### PR DESCRIPTION
This pull request includes updates to the `README` files to improve documentation and installation instructions for the `biodiversityhorizons` package.

Documentation improvements:

* [`README.Rmd`](diffhunk://#diff-72778b58969c8ca8268402860b0e003e3d213a26c812bc9f9b928395c284c99fR19-R32): Added a code coverage badge and updated the installation instructions to include steps for installing `devtools` and the `biodiversityhorizons` package.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R1-R33): Generated from `README.Rmd`, includes the new code coverage badge and updated installation instructions.

Removal of unnecessary content:

* [`README.Rmd`](diffhunk://#diff-72778b58969c8ca8268402860b0e003e3d213a26c812bc9f9b928395c284c99fL40-L54): Removed example R chunks and instructions for embedding plots to simplify the README.